### PR TITLE
Minor change in download script for NixOS compatibility

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
+PHARO_VERSION=${PHARO_VERSION:-5.0}
 VM_INSTALL_URL="http://get.pharo.org/vm"
-IMAGE_URL="https://ci.inria.fr/pharo-contribution/job/Pillar/PHARO=40,VERSION=stable,VM=vm/lastSuccessfulBuild/artifact/Pillar.zip"
+IMAGE_URL="https://ci.inria.fr/pharo-contribution/job/Pillar/PHARO=$(echo "${PHARO_VERSION}" | tr -d '.'),VERSION=stable,VM=vm/lastSuccessfulBuild/artifact/Pillar.zip"
+which pharo > /dev/null 2>&1
+PHARO_VM_AVAILABLE=$?
+PHARO_VM=${PHARO_VM:-$(which pharo 2> /dev/null)}
 PHARO_VM=${PHARO_VM:-./pharo}
 
 usage() {
@@ -16,10 +20,12 @@ HELP
 }
 
 get_vm() {
-    if [ -d pharo-vm ]; then
-        rm -rf pharo-vm
+    if [ ! ${PHARO_VM_AVAILABLE} ]; then
+        if [ -d pharo-vm ]; then
+            rm -rf pharo-vm
+        fi
+        wget ${CERTCHECK} --output-document - "$VM_INSTALL_URL" | bash
     fi
-    wget ${CERTCHECK} --output-document - "$VM_INSTALL_URL" | bash
 }
 
 get_image() {


### PR DESCRIPTION
- The Pillar.zip url is no longer valid. It requires Pharo 5.0 or above.
- In NixOS, the usual way of installing Pharo VM does not work. The proposed changes try to use already-existing pharo-vm installation if possible, before downloading and installing it ourselves.
- I also had to make some changes in the **pillar** script that gets downloaded:
```
index 01a9404..d3bb33f 100755
--- a/../Magritte-orig/pillar
+++ b/pillar
@@ -3,10 +3,14 @@
 # PHARO_VM=${PHARO_VM:-./pharo}
 # PILLAR_IMAGE=${PILLAR_IMAGE:-./Pharo.image}

-PHARO_VM=${PHARO_VM}
-# ./pharo has a higher priority than PHARO_VM env if it exists
-if [ -f pharo ]; then
-       PHARO_VM="./pharo"
+which pharo > /dev/null 2>&1
+PHARO_VM_AVAILABLE=$?;
+PHARO_VM=${PHARO_VM:-$(which pharo 2> /dev/null)}
+if [ ! ${PHARO_VM_AVAILABLE} ]; then
+    # ./pharo has a higher priority than PHARO_VM env if it exists
+    if [ -f pharo ]; then
+       PHARO_VM="./pharo"
+    fi
 fi
```
